### PR TITLE
Make the resultTemplate work

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -12,6 +12,9 @@ module.exports =
     scope:
       type: 'string'
       default: '.source.gfm'
+    ignoreScope:
+      type: 'string'
+      default: '.comment'
     resultTemplate:
       type: 'string'
       default: '@[key]'

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -10,6 +10,7 @@ module.exports =
 class ReferenceProvider
 
   atom.deserializers.add(this)
+
   @deserialize: ({data}) -> new ReferenceProvider(data)
 
   constructor: (state) ->
@@ -33,7 +34,7 @@ class ReferenceProvider
 
     @provider =
       selector: atom.config.get "autocomplete-bibtex.scope"
-      disableForSelector: ".comment"
+      disableForSelector: atom.config.get "autocomplete-bibtex.scope"
       inclusionPriority: 1
       excludeLowerPriority: true
 
@@ -54,10 +55,12 @@ class ReferenceProvider
             for h in hits
               h.score = fuzzaldrin.score(p, h.author)
             hits.sort @compare
+            resultTemplate = atom.config.get "autocomplete-bibtex.resultTemplate"
             for word in hits
               suggestion = {
-                text: word.key
+                text: resultTemplate.replace("[key]", word.key)
                 displayText: word.label
+                replacementPrefix: prefix
                 leftLabel: word.key
                 rightLabel: word.by
                 className: word.type
@@ -82,7 +85,6 @@ class ReferenceProvider
         # Match the regex to the line, and return the match
         line.match(regex)?[0] or ''
 
-    # return provider
 
   serialize: -> {
     deserializer: 'ReferenceProvider'


### PR DESCRIPTION
In experimenting with using Asciidoc and Asciidoctor as a source format, I was led to try and get the resulting citekey template to change from its default. After digging around it sure looked like it was simply being ignored. Hopefully this pull request fixes that adequately.

I also added a configuration parameter for ignored scope, as I still want autocomplete in my comments, personally.

Cheers. :beers: 
